### PR TITLE
Obfuscate participant ids in the urls for security

### DIFF
--- a/app/controllers/giftings_controller.rb
+++ b/app/controllers/giftings_controller.rb
@@ -3,7 +3,7 @@ class GiftingsController < ApplicationController
   def confirm
     gifting = Gifting.find_by(confirm_token: params[:confirm_token])
     gifting.confirmed!
-    redirect_to "/participants/#{gifting.participant_id}/edit"
+    redirect_to "/participants/#{gifting.confirm_token}/edit"
   end
 
 end

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -1,4 +1,5 @@
 class ParticipantsController < ApplicationController
+  before_action :find_participant, only: [:edit, :update]
 
   def create
     @participant = Participant.create(participants_params)
@@ -6,11 +7,9 @@ class ParticipantsController < ApplicationController
   end
 
   def edit
-    @participant = Participant.find(params[:id])
   end
 
   def update
-    @participant = Participant.find(params[:id])
     @participant.update({ gift_preferences: Array.wrap(update_params[:gift_preferences]) })
     GiftingMailer.share_preferences(Gifting.find_by(giftee: @participant)).deliver_later
     redirect_to "/participants/success"
@@ -27,5 +26,10 @@ class ParticipantsController < ApplicationController
 
   def update_params
     params.require(:participant).permit(:gift_preferences)
+  end
+
+  def find_participant
+    gifting = Gifting.find_by(confirm_token: params[:confirm_token])
+    @participant = gifting.participant
   end
 end

--- a/app/views/participants/edit.html.erb
+++ b/app/views/participants/edit.html.erb
@@ -5,7 +5,7 @@
   <% if !@participant.party.theme.empty? %>
   <p class="participant-confirm-theme">Party Theme: <%= @participant.party.theme %></p>
   <% end %>
-  <%= form_for(@participant) do |participant| %>
+  <%= form_for(@participant, url: { action: "update", confirm_token: @participant.gifting.confirm_token }) do |participant| %>
 
     <div class="field">
       <%= participant.text_field :gift_preferences, placeholder: "Preferences..." %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   resources :parties, only: [:show, :new, :create]
   get "parties/:id/create_giftings" => "parties#create_giftings"
-  resources :participants, only: [:create, :edit, :update]
+  resources :participants, only: [:create, :edit, :update], param: :confirm_token
 
   get "confirm/:confirm_token" => "giftings#confirm"
 


### PR DESCRIPTION
- Use the gifting confirm_token instead
